### PR TITLE
Update lane.py

### DIFF
--- a/utils/lane_evaluation/tusimple/lane.py
+++ b/utils/lane_evaluation/tusimple/lane.py
@@ -1,6 +1,7 @@
 import numpy as np
 from sklearn.linear_model import LinearRegression
 import json as json
+import platform
 
 
 class LaneEval(object):
@@ -67,6 +68,8 @@ class LaneEval(object):
             if 'raw_file' not in pred or 'lanes' not in pred or 'run_time' not in pred:
                 raise Exception('raw_file or lanes or run_time not in some predictions.')
             raw_file = pred['raw_file']
+            if platform.system() == 'Windows':
+                raw_file = raw_file.replace('\\', '/')  # windows环境需要加这行代码
             pred_lanes = pred['lanes']
             run_time = pred['run_time']
             if raw_file not in gts:


### PR DESCRIPTION
由于test_label.json里面的"raw_file": "clips/0530/1492626760788443246_0/20.jpg"跟windows下生成的predict_test.json里面"raw_file": "clips\\\0530\\\1492626760788443246_0\\\20.jpg"无法匹配，导致if raw_file not in gts:raise Exception('Some raw_file from your predictions do not exist in the test tasks.')。所以加入代码判断是否为win平台，如果是的话就对“\\\”进行替换，这样就不会报错，也能得到输出结果。