### PR TITLE
Fixed a CULane testing bug that produces more FP

### DIFF
--- a/test_CULane.py
+++ b/test_CULane.py
@@ -101,9 +101,10 @@ with torch.no_grad():
 
             with open(save_name, "w") as f:
                 for l in lane_coords:
-                    for (x, y) in l:
-                        print("{} {}".format(x, y), end=" ", file=f)
-                    print(file=f)
+                    if l:  # No printing for []
+                        for (x, y) in l:
+                            print("{} {}".format(x, y), end=" ", file=f)
+                        print(file=f)
 
         progressbar.update(1)
 progressbar.close()


### PR DESCRIPTION
#39 reports an error message thrown by the official testing script "lane size must be greater or equal to 2".
I found the same error message when trying to use codes from this repo for my own SCNN-ERFNet [code](https://github.com/voldemortX/pytorch-auto-drive) and with careful debugging I believe it is not because my model have only 1 evaluation dot for a line, but because the prob2line part of this repo can print empty lines which results in a FP (false positive) count in the official testing script.

For example, some results look like this:

\<Empty line\>
1285.0 589 1248.0 569 1203.0 549 1156.0 529 1100.0 509 1053.0 489 1000.0 469 942.0 449 889.0 
1637.0 509 1574.0 489 1471.0 469 1369.0 449 1256.0 429 1148.0 409 1014.0 389 877.0 369 

**Then in testing the \<Empty line\> throws the error and is count as FP.** 

The overall FP should be noticeably lower with this bug fixed, I find about 2% FP drop in my repo and about 0.3% increase on F1 measure, a re-evaluation of this repo is recommended.